### PR TITLE
fix: fix etcd Txn nested response headers for STM

### DIFF
--- a/api/etcd/kv.go
+++ b/api/etcd/kv.go
@@ -160,14 +160,15 @@ func (s *KVServer) Txn(ctx context.Context, req *pb.TxnRequest) (*pb.TxnResponse
 	}
 
 	// 转换响应
+	header := s.server.getResponseHeader()
 	resp := &pb.TxnResponse{
-		Header:    s.server.getResponseHeader(),
+		Header:    header,
 		Succeeded: txnResp.Succeeded,
 		Responses: make([]*pb.ResponseOp, len(txnResp.Responses)),
 	}
 
 	for i, opResp := range txnResp.Responses {
-		resp.Responses[i] = convertOpResponse(opResp)
+		resp.Responses[i] = convertOpResponse(opResp, header)
 	}
 
 	// 更新 header 中的 revision
@@ -252,7 +253,7 @@ func convertRequestOp(reqOp *pb.RequestOp) kvstore.Op {
 }
 
 // 辅助函数：转换 OpResponse
-func convertOpResponse(opResp kvstore.OpResponse) *pb.ResponseOp {
+func convertOpResponse(opResp kvstore.OpResponse, header *pb.ResponseHeader) *pb.ResponseOp {
 	resp := &pb.ResponseOp{}
 
 	switch opResp.Type {
@@ -271,15 +272,16 @@ func convertOpResponse(opResp kvstore.OpResponse) *pb.ResponseOp {
 			}
 			resp.Response = &pb.ResponseOp_ResponseRange{
 				ResponseRange: &pb.RangeResponse{
-					Kvs:   kvs,
-					More:  opResp.RangeResp.More,
-					Count: opResp.RangeResp.Count,
+					Header: header,
+					Kvs:    kvs,
+					More:   opResp.RangeResp.More,
+					Count:  opResp.RangeResp.Count,
 				},
 			}
 		}
 	case kvstore.OpPut:
 		if opResp.PutResp != nil {
-			putResp := &pb.PutResponse{}
+			putResp := &pb.PutResponse{Header: header}
 			if opResp.PutResp.PrevKv != nil {
 				putResp.PrevKv = &mvccpb.KeyValue{
 					Key:            opResp.PutResp.PrevKv.Key,
@@ -297,6 +299,7 @@ func convertOpResponse(opResp kvstore.OpResponse) *pb.ResponseOp {
 	case kvstore.OpDelete:
 		if opResp.DeleteResp != nil {
 			deleteResp := &pb.DeleteRangeResponse{
+				Header:  header,
 				Deleted: opResp.DeleteResp.Deleted,
 			}
 			if len(opResp.DeleteResp.PrevKvs) > 0 {


### PR DESCRIPTION
Prior to the code modification, STM was utilized for access
```golang
_, err := concurrency.NewSTM(r.client, func(stm concurrency.STM) error {
		value := stm.Get(key)
		if value == "" {
			return errors.New("node not found") // Return error if node not found
		}

		var node Node
		if err := json.Unmarshal([]byte(value), &node); err != nil {
			return err
		}

		updateFn(&node) // Call the update function to modify the node

		newData, err := json.Marshal(node)
		if err != nil {
			return err
		}

		stm.Put(key, string(newData)) // Update the node in etcd
		return nil
	})
```
The client error is as follows:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xc7bae0]
goroutine 71 [running]:
go.etcd.io/etcd/client/v3/concurrency.runSTM.func1.1()
/home/go/pkg/mod/go.etcd.io/etcd/client/v3@v3.5.15/concurrency/stm.go:148 +0x6a
panic({0xe6d140?, 0x18b0ab0?})
/usr/local/go/src/runtime/panic.go:783 +0x132
go.etcd.io/etcd/client/v3/concurrency.(*stmSerializable).Get(0xc00028ee10, {0xc0000b38c0, 0x1, 0x1})
/home/go/pkg/mod/go.etcd.io/etcd/client/v3@v3.5.15/concurrency/stm.go:320 +0x320
code.sangfor.org/imp/paas-platform/tools/mha/pkg/task/executor.(*etcdRegistry).updateNodeField.func1({0x1157a08, 0xc00028ee10})
/home/go/src/database/pkg/task/executor/etcd.go:147 +0x93
go.etcd.io/etcd/client/v3/concurrency.runSTM.func1()
/home/go/pkg/mod/go.etcd.io/etcd/client/v3@v3.5.15/concurrency/stm.go:156 +0x97
created by go.etcd.io/etcd/client/v3/concurrency.runSTM in goroutine 1
/home/go/pkg/mod/go.etcd.io/etcd/client/v3@v3.5.15/concurrency/stm.go:142 +0xa5
```

No panic errors after the fix