### PR TITLE
feat: implement port multiplexing for etcd gRPC and HTTP API using cm…

### DIFF
--- a/api/etcd/server.go
+++ b/api/etcd/server.go
@@ -28,28 +28,28 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/raft/v3/raftpb"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Server etcd-compatible gRPC server
 type Server struct {
 	mu       sync.RWMutex
-	store    kvstore.Store    // Underlying storage
-	grpcSrv  *grpc.Server     // gRPC server
-	listener net.Listener     // Network listener
+	store    kvstore.Store // Underlying storage
+	grpcSrv  *grpc.Server  // gRPC server
+	listener net.Listener  // Network listener
 
 	// Management components
-	watchMgr   *WatchManager    // Watch manager
-	leaseMgr   *LeaseManager    // Lease manager
-	clusterMgr *ClusterManager  // Cluster manager
-	authMgr    *AuthManager     // Auth manager
-	alarmMgr   *AlarmManager    // Alarm manager
+	watchMgr   *WatchManager   // Watch manager
+	leaseMgr   *LeaseManager   // Lease manager
+	clusterMgr *ClusterManager // Cluster manager
+	authMgr    *AuthManager    // Auth manager
+	alarmMgr   *AlarmManager   // Alarm manager
 
 	// Reliability components
-	shutdownMgr  *reliability.GracefulShutdown  // Graceful shutdown manager
-	resourceMgr  *reliability.ResourceManager   // Resource manager
-	healthMgr    *reliability.HealthManager     // Health manager
+	shutdownMgr   *reliability.GracefulShutdown // Graceful shutdown manager
+	resourceMgr   *reliability.ResourceManager  // Resource manager
+	healthMgr     *reliability.HealthManager    // Health manager
 	dataValidator *reliability.DataValidator    // Data validator
 
 	// Configuration
@@ -60,19 +60,20 @@ type Server struct {
 
 // ServerConfig server configuration
 type ServerConfig struct {
-	Store       kvstore.Store              // Underlying storage (required)
-	Address     string                     // Listen address (e.g. ":2379")
-	ClusterID   uint64                     // Cluster ID
-	MemberID    uint64                     // Member ID
-	ClusterPeers []string                  // Peer URLs of all cluster members (for member list)
-	ConfChangeC chan<- raftpb.ConfChange   // Raft ConfChange channel (optional)
-	Config      *config.Config             // Full configuration object (optional, values from this take precedence if provided)
+	Store        kvstore.Store            // Underlying storage (required)
+	Address      string                   // Listen address (e.g. ":2379")
+	ClusterID    uint64                   // Cluster ID
+	MemberID     uint64                   // Member ID
+	ClusterPeers []string                 // Peer URLs of all cluster members (for member list)
+	ConfChangeC  chan<- raftpb.ConfChange // Raft ConfChange channel (optional)
+	Config       *config.Config           // Full configuration object (optional, values from this take precedence if provided)
+	Listener     net.Listener             // External listener (optional, if provided, Address is ignored)
 
 	// Reliability configuration (kept for backward compatibility, but overridden if Config is provided)
-	ResourceLimits    *reliability.ResourceLimits  // Resource limits configuration (optional)
-	ShutdownTimeout   time.Duration                // Shutdown timeout (optional, default 30s)
-	EnableCRC         bool                         // Whether to enable CRC validation (optional, default false)
-	EnableHealthCheck bool                         // Whether to enable health check (optional, default true)
+	ResourceLimits    *reliability.ResourceLimits // Resource limits configuration (optional)
+	ShutdownTimeout   time.Duration               // Shutdown timeout (optional, default 30s)
+	EnableCRC         bool                        // Whether to enable CRC validation (optional, default false)
+	EnableHealthCheck bool                        // Whether to enable health check (optional, default true)
 }
 
 // NewServer creates a new etcd-compatible server
@@ -127,9 +128,15 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 
 	// Create listener
-	listener, err := net.Listen("tcp", cfg.Address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on %s: %v", cfg.Address, err)
+	var listener net.Listener
+	var err error
+	if cfg.Listener != nil {
+		listener = cfg.Listener
+	} else {
+		listener, err = net.Listen("tcp", cfg.Address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to listen on %s: %v", cfg.Address, err)
+		}
 	}
 
 	// Initialize reliability components
@@ -400,6 +407,14 @@ func (s *Server) Start() error {
 
 	// Start gRPC service
 	return s.grpcSrv.Serve(s.listener)
+}
+
+// Serve accepts a listener and serves gRPC requests on it.
+func (s *Server) Serve(l net.Listener) error {
+	s.mu.Lock()
+	s.listener = l
+	s.mu.Unlock()
+	return s.Start()
 }
 
 // Stop stops the gRPC server (triggers graceful shutdown)

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -17,6 +17,7 @@ package http
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,7 +29,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// Server HTTP API server
 type Server struct {
 	store       kvstore.Store
 	confChangeC chan<- raftpb.ConfChange
@@ -51,6 +51,7 @@ func NewServer(cfg Config) *Server {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", s)
+	mux.HandleFunc("/version", s.handleVersion)
 
 	s.httpServer = &http.Server{
 		Addr:    ":" + strconv.Itoa(cfg.Port),
@@ -66,7 +67,12 @@ func (s *Server) Start() error {
 	return s.httpServer.ListenAndServe()
 }
 
-// Stop stops the HTTP server
+// Serve 接收监听器并处理 HTTP 请求 (用于多路复用)
+func (s *Server) Serve(l net.Listener) error {
+	log.Info("Starting HTTP API server on multiplexed listener", zap.String("component", "http"))
+	return s.httpServer.Serve(l)
+}
+
 func (s *Server) Stop() error {
 	log.Info("Stopping HTTP API server", zap.String("component", "http"))
 	return s.httpServer.Close()
@@ -244,4 +250,20 @@ func ServeHTTPKVAPI(kv kvstore.Store, port int, confChangeC chan<- raftpb.ConfCh
 	if err, ok := <-errorC; ok {
 		log.Fatal("Raft error", zap.Error(err), zap.String("component", "http"))
 	}
+}
+
+// handleVersion handles the /version endpoint for etcd compatibility
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	// Only handle GET requests for version info
+	if r.Method != http.MethodGet {
+		// Fallback to KV logic for other methods (e.g. valid KV operations on key "version")
+		s.ServeHTTP(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	// Return versions compatible with etcd clients
+	// etcdserver: 3.6.0
+	// etcdcluster: 3.5.0 (safe default)
+	w.Write([]byte(`{"etcdserver":"3.6.0","etcdcluster":"3.5.0"}`))
 }

--- a/cmd/metastore/main.go
+++ b/cmd/metastore/main.go
@@ -17,19 +17,22 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
-	// "metaStore/internal/batch" // disabled BatchProposer
+	"github.com/soheilhy/cmux"
+
+	// "metaStore/internal/batch" // 已禁用 BatchProposer
+	"metaStore/api/etcd"
+	"metaStore/api/http"
+	"metaStore/api/mysql"
 	"metaStore/internal/memory"
 	"metaStore/internal/raft"
 	"metaStore/internal/rocksdb"
 	"metaStore/pkg/config"
-	"metaStore/api/etcd"
-	"metaStore/api/http"
 	"metaStore/pkg/log"
 	"metaStore/pkg/metrics"
-	"metaStore/api/mysql"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.etcd.io/raft/v3/raftpb"
@@ -167,12 +170,6 @@ func main() {
 		// inject raft node reference，used to getstatus info
 		kvs.SetRaftNode(raftNode, cfg.Server.MemberID)
 
-		// Start HTTP API server
-		go func() {
-			log.Info("Starting HTTP API", zap.Int("port", *kvport), zap.String("component", "main"))
-			http.ServeHTTPKVAPI(kvs, *kvport, confChangeC, errorC)
-		}()
-
 		// Start MySQL protocol server
 		mysqlServer, err := mysql.NewServer(mysql.ServerConfig{
 			Store:    kvs,
@@ -198,6 +195,32 @@ func main() {
 			}
 		}()
 
+		// Start unified listener (cmux)
+		log.Info("Starting unified listener", zap.String("address", cfg.Server.Etcd.Address), zap.String("component", "main"))
+		l, err := net.Listen("tcp", cfg.Server.Etcd.Address)
+		if err != nil {
+			log.Fatalf("Failed to listen on %s: %v", cfg.Server.Etcd.Address, err)
+			os.Exit(-1)
+		}
+
+		m := cmux.New(l)
+		grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+		httpL := m.Match(cmux.HTTP1Fast())
+
+		// Start HTTP API server
+		httpServer := http.NewServer(http.Config{
+			Store:       kvs,
+			Port:        *kvport, // Configured port (mostly for display/struct init)
+			ConfChangeC: confChangeC,
+		})
+
+		go func() {
+			log.Info("Starting HTTP API on multiplexed listener", zap.String("component", "main"))
+			if err := httpServer.Serve(httpL); err != nil {
+				log.Error("HTTP API server failed", zap.Error(err), zap.String("component", "main"))
+			}
+		}()
+
 		// Start etcd gRPC server
 		log.Info("Starting etcd gRPC server",
 			zap.String("address", cfg.Server.Etcd.Address),
@@ -212,6 +235,7 @@ func main() {
 			ClusterPeers: strings.Split(*cluster, ","),
 			ConfChangeC:  confChangeC,
 			Config:       cfg,
+			Listener:     grpcL, // Inject matched listener
 		})
 		if err != nil {
 			log.Fatalf("Failed to create etcd server: %v", err)
@@ -219,10 +243,18 @@ func main() {
 			return
 		}
 
-		if err := etcdServer.Start(); err != nil {
-			log.Fatalf("etcd server failed: %v", err)
+		go func() {
+			if err := etcdServer.Start(); err != nil {
+				log.Fatalf("etcd server failed: %v", err)
+				os.Exit(-1)
+			}
+		}()
+
+		// Block on cmux serving
+		log.Info("Starting cmux multiplexing", zap.String("address", cfg.Server.Etcd.Address), zap.String("component", "main"))
+		if err := m.Serve(); err != nil {
+			log.Fatalf("cmux failed: %v", err)
 			os.Exit(-1)
-			return
 		}
 
 	case "memory":
@@ -238,12 +270,6 @@ func main() {
 		// inject raft node reference，used to getstatus info
 		kvs.SetRaftNode(raftNode, cfg.Server.MemberID)
 
-		// Start HTTP API server
-		go func() {
-			log.Info("Starting HTTP API", zap.Int("port", *kvport), zap.String("component", "main"))
-			http.ServeHTTPKVAPI(kvs, *kvport, confChangeC, errorC)
-		}()
-
 		// Start MySQL protocol server
 		mysqlServer, err := mysql.NewServer(mysql.ServerConfig{
 			Store:    kvs,
@@ -269,6 +295,32 @@ func main() {
 			}
 		}()
 
+		// Start unified listener (cmux)
+		log.Info("Starting unified listener", zap.String("address", cfg.Server.Etcd.Address), zap.String("component", "main"))
+		l, err := net.Listen("tcp", cfg.Server.Etcd.Address)
+		if err != nil {
+			log.Fatalf("Failed to listen on %s: %v", cfg.Server.Etcd.Address, err)
+			os.Exit(-1)
+		}
+
+		m := cmux.New(l)
+		grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+		httpL := m.Match(cmux.HTTP1Fast())
+
+		// Start HTTP API server
+		httpServer := http.NewServer(http.Config{
+			Store:       kvs,
+			Port:        *kvport,
+			ConfChangeC: confChangeC,
+		})
+
+		go func() {
+			log.Info("Starting HTTP API on multiplexed listener", zap.String("component", "main"))
+			if err := httpServer.Serve(httpL); err != nil {
+				log.Error("HTTP API server failed", zap.Error(err), zap.String("component", "main"))
+			}
+		}()
+
 		// Start etcd gRPC server
 		log.Info("Starting etcd gRPC server",
 			zap.String("address", cfg.Server.Etcd.Address),
@@ -283,6 +335,7 @@ func main() {
 			ClusterPeers: strings.Split(*cluster, ","),
 			ConfChangeC:  confChangeC,
 			Config:       cfg,
+			Listener:     grpcL, // Inject matched listener
 		})
 		if err != nil {
 			log.Fatalf("Failed to create etcd server: %v", err)
@@ -290,10 +343,18 @@ func main() {
 			return
 		}
 
-		if err := etcdServer.Start(); err != nil {
-			log.Fatalf("etcd server failed: %v", err)
+		go func() {
+			if err := etcdServer.Start(); err != nil {
+				log.Fatalf("etcd server failed: %v", err)
+				os.Exit(-1)
+			}
+		}()
+
+		// Block on cmux serving
+		log.Info("Starting cmux multiplexing", zap.String("address", cfg.Server.Etcd.Address), zap.String("component", "main"))
+		if err := m.Serve(); err != nil {
+			log.Fatalf("cmux failed: %v", err)
 			os.Exit(-1)
-			return
 		}
 
 	default:

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
@@ -144,6 +146,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Problem description
Patroni attempts to fetch the etcd version via HTTP using the code below; however, the current Metastore implementation does not support retrieving version information via HTTP.
``` python
def _ensure_version_prefix(self, base_uri: str, **kwargs: Any) -> None:
        if self.version_prefix != '/v3':
            response = self.http.urlopen(self._MGET, base_uri + '/version', **kwargs)
            response = self._handle_server_response(response)

            server_version_str = response['etcdserver']
            server_version = tuple(int(x) for x in server_version_str.split('.'))
            cluster_version_str = response['etcdcluster']
            self._cluster_version = tuple(int(x) for x in cluster_version_str.split('.'))
            ...
```

## Solution 
Following the approach taken by etcd, use multiplexing to handle both HTTP and gRPC requests on the same port.